### PR TITLE
PM on Classic infra

### DIFF
--- a/pm/config/argocd/classic/pm-prod-instance-app.yaml
+++ b/pm/config/argocd/classic/pm-prod-instance-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pm-prod-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: prod
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: pm/environments/classic
+    repoURL: https://github.com/jesusmah/multi-tenancy-gitops-apps.git
+    targetRevision: master
+  syncPolicy: {}

--- a/pm/config/argocd/classic/pm-prod-instance-app.yaml
+++ b/pm/config/argocd/classic/pm-prod-instance-app.yaml
@@ -13,6 +13,6 @@ spec:
   project: applications
   source:
     path: pm/environments/classic
-    repoURL: https://github.com/jesusmah/multi-tenancy-gitops-apps.git
+    repoURL: https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
     targetRevision: master
   syncPolicy: {}

--- a/pm/environments/classic/ibm-process-mining-prod.yaml
+++ b/pm/environments/classic/ibm-process-mining-prod.yaml
@@ -1,0 +1,37 @@
+apiVersion: processmining.ibm.com/v1beta1
+kind: ProcessMining
+metadata:
+  name: process-mining-prod
+  namespace: prod
+spec:
+  defaultStorageClassName: ibmc-file-gold-gid
+  license:
+    accept: true
+    cloudPak: IBM Cloud Pak for Business Automation
+  loglevel: INFO
+  processmining:
+    images:
+      imagepullpolicy: Always
+    storage:
+      database:
+        create: true
+        name: processmining-mongo
+        size: '10'
+      events:
+        create: true
+        name: processmining-repository
+        size: '50'
+  taskmining:
+    images:
+      imagepullpolicy: Always
+    install: true
+    storage:
+      database:
+        create: true
+        name: taskmining-mysql
+        size: '10'
+      events:
+        create: true
+        name: taskmining-data
+        size: '100'
+  version: 1.10.2


### PR DESCRIPTION
PM on Classic infra. The only difference is that the PM instance uses IBM Cloud File storage class.
This is only valid for single region ROKS. For MZR ROKS there is no native file storage (RWX) so Portworx (dont think we want to go down this path) or ODF (I believe this should be our preferred option) should be installed/enabled. Therefore, to install PM on MZR classic infra, we can leverage the existing PM on VPC work.