### PR TITLE
Enable insucure deployment only

### DIFF
--- a/soapserver/environments/soapserver/kustomization.yaml
+++ b/soapserver/environments/soapserver/kustomization.yaml
@@ -1,9 +1,9 @@
 resources:
-- deployments/soapserver-deployment.yaml
+# - deployments/soapserver-deployment.yaml
 - deployments/soapserver-nonsecure-deployment.yaml
-- routes/soapserver-route.yaml
+# - routes/soapserver-route.yaml
 - routes/soapserver-nonsecure-route.yaml
-- secrets/ibm-jks-secret.yaml
-- secrets/ibm-passwords-secret.yaml
-- services/soapserver-svc.yaml
+# - secrets/ibm-jks-secret.yaml
+# - secrets/ibm-passwords-secret.yaml
+# - services/soapserver-svc.yaml
 - services/soapserver-nonsecure-svc.yaml


### PR DESCRIPTION
In the guide, we will progressively deploy the non-secure version first, and then the secure one.

As such, just want to disable secure version of the soapserver.