### PR TITLE
Using LUR as opposed to OIDC for APIC CP4i

### DIFF
--- a/apic/environments/single-cluster-cp4i/pipelines/apic-publish-pipeline.yaml
+++ b/apic/environments/single-cluster-cp4i/pipelines/apic-publish-pipeline.yaml
@@ -32,9 +32,6 @@ spec:
       type: string
       default: tools
       description: OpenShift project where your IBM API Connect Cluster v10 has been deployed into
-    - name: api-key
-      type: string
-      description: Api Key to log into IBM API Connect through the IBM Common Services OIDC Provider
     - name: debug
       type: string
       default: "True"
@@ -63,9 +60,6 @@ spec:
       # OpenShift project where your IBM API Connect Cluster v10 has been deployed into.
       - name: apic-project
         value: "$(params.apic-project)"
-      # Api Key to log into IBM API Connect through the IBM Common Services OIDC Provider
-      - name: api-key
-        value: "$(params.api-key)"
       # Debug flag
       - name: debug
         value: "$(params.debug)"

--- a/apic/environments/single-cluster-cp4i/tasks/apic-publish-task.yaml
+++ b/apic/environments/single-cluster-cp4i/tasks/apic-publish-task.yaml
@@ -53,9 +53,6 @@ spec:
       type: string
       default: tools
       description: OpenShift project where your IBM API Connect Cluster v10 has been deployed into.
-    - name: api-key
-      type: string
-      description: Api Key to log into IBM API Connect through the IBM Common Services OIDC Provider
     - name: debug
       type: string
       default: "True"
@@ -85,8 +82,6 @@ spec:
         value: $(params.git-products-path)
       - name: GIT_APIS_PATH
         value: $(params.git-apis-path)
-      - name: OIDC_API_KEY
-        value: $(params.api-key)
   steps:
     - name: pipeline-config
       image: quay.io/ibmgaragecloud/alpine-git


### PR DESCRIPTION
Removing the need of an API KEY for the API Publish APIs and Products pipeline since there is a bug in Foundational Services that prevents to return appropriate email value when APIC reaching out to the OIDC registry for A&A.

As a result, I've modified the tutorial to use Local User Registries that do not require of API KEY for A&A

Signed-off-by: Jesus Almaraz <jesus.mah@gmail.com>