### PR TITLE
Updating EventStreams scenario for newer version with some fixes

### DIFF
--- a/es/config/argocd/dev/starter-app/dev-es-starter-app-instance.yaml
+++ b/es/config/argocd/dev/starter-app/dev-es-starter-app-instance.yaml
@@ -7,12 +7,13 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  ignoreDifferences:
-  - group: route.openshift.io/v1
-    kind: route
-    name: es-starter-app
-    jsonPointers:
-    - /spec/host
+  # The following is not needed anymore as the route has been specified without the host property
+  # ignoreDifferences:
+  # - group: route.openshift.io/v1
+  #   kind: route
+  #   name: es-starter-app
+  #   jsonPointers:
+  #   - /spec/host
   destination:
     namespace: dev
     server: https://kubernetes.default.svc

--- a/es/environments/base/event-streams/event-streams.yaml
+++ b/es/environments/base/event-streams/event-streams.yaml
@@ -5,7 +5,9 @@ metadata:
 spec:
   security:
     internalTls: NONE
-  version: 11.0.2
+  # Make sure this Event Streams Operand version is the correct version for the Event Streams Operator version being installed.
+  # As of Event Streams Operator versions 3.x, there is no backwards compatibility so the versions of the Event Streams Operator and Operand must match the correct levels.
+  version: 11.0.4
   license:
     # By installing this product you accept the license terms at https://ibm.biz/es-license
     accept: true

--- a/es/environments/base/event-streams/kustomization.yaml
+++ b/es/environments/base/event-streams/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
+  # This was introduced with the latest versions of Strimzi where the metrics configuration is read from a configmap that needs to be created beforehand.
+  # Do not know whey the EventStreams operator does not create a default one out of the box though.
+  - ./metrics-config.yaml
   - ./event-streams.yaml

--- a/es/environments/base/event-streams/metrics-config.yaml
+++ b/es/environments/base/event-streams/metrics-config.yaml
@@ -1,0 +1,23 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: metrics-config
+data:
+  kafka-metrics-config.yaml: |
+    lowercaseOutputName: true
+    rules:
+    - attrNameSnakeCase: false
+      name: kafka_controller_$1_$2_$3
+      pattern: kafka.controller<type=(\\w+), name=(\\w+)><>(Count|Value|Mean)
+    - attrNameSnakeCase: false
+      name: kafka_server_BrokerTopicMetrics_$1_$2
+      pattern: kafka.server<type=BrokerTopicMetrics, name=(BytesInPerSec|BytesOutPerSec)><>(Count)
+    - attrNameSnakeCase: false
+      name: kafka_server_BrokerTopicMetrics_$1__alltopics_$2
+      pattern: kafka.server<type=BrokerTopicMetrics, name=(BytesInPerSec|BytesOutPerSec)><>(OneMinuteRate)
+    - attrNameSnakeCase: false
+      name: kafka_server_ReplicaManager_$1_$2
+      pattern: kafka.server<type=ReplicaManager, name=(\\w+)><>(Value)
+  zookeeper-metrics-config.yaml: |
+    lowercaseOutputName: true
+    rules: []

--- a/es/environments/base/starter-app/route.yaml
+++ b/es/environments/base/starter-app/route.yaml
@@ -2,11 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: es-starter-app
-  # annotations:
-  #   argocd.argoproj.io/sync-options: Validate=false
 spec:
-  host: ""
-  path: /
   port:
     targetPort: 8080
   to:

--- a/es/environments/base/starter-app/topic.yaml
+++ b/es/environments/base/starter-app/topic.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     eventstreams.ibm.com/cluster: dev-es-inst
 spec:
-  partitions: 3 
-  replicas: 3
+  partitions: 1
+  replicas: 1
   config:
-    min.insync.replicas: 2
+    min.insync.replicas: 1
     cleanup.policy: delete
     retention.ms: 604800000
     segment.ms: 604800000


### PR DESCRIPTION
1. Updating to the latest version for the Event Streams Operand. Since Event Streams Operator version 3.x, the operator isnt backwards compatible. As a result, you need to keep up to date the Event Streams Operand version to match.
2. As a result of the above, the latest version of Event Streams (in fact, the latest version of Strimzi), requires the monitoring configuration on an external configmap.
3. Deleted the `host` property for the ES application's route so that the ArgoCD application that takes care of the ES app does not remain in out of sync status.
4. Fixed the topic to have just 1 replica as Kafka gets deployed with a single broker.
Signed-off-by: Jesus Almaraz <jesus.mah@gmail.com>